### PR TITLE
Adds support for levels and any other Ruby Logger method

### DIFF
--- a/lib/composite_logging/logger_builder.rb
+++ b/lib/composite_logging/logger_builder.rb
@@ -4,6 +4,7 @@ module CompositeLogging
     def initialize(logger_class = TaggedLogger, &block)
       @logger_class = logger_class
       @formatter_attrs = {}
+      @logger_attrs = {}
 
       instance_eval(&block)
     end
@@ -11,6 +12,8 @@ module CompositeLogging
     def build
       logger = @logger_class.new(*@output_args)
       logger.formatter = @formatter_class.new(@formatter_attrs) if @formatter_class
+      logger.level = @logger_attrs[:level] if @logger_attrs.present?
+
       logger
     end
 
@@ -25,6 +28,8 @@ module CompositeLogging
     def method_missing(name, *args, &block)
       if @formatter_class && @formatter_class.public_instance_methods.include?(:"#{name}=")
         @formatter_attrs[name] = args.first
+      elsif @logger_class.public_instance_methods.include?(:"#{name}=")
+        @logger_attrs[name] = args.first
       else
         super
       end


### PR DESCRIPTION
 - in order to have more robust logging, we'd like to
   use the Ruby Logger class levels (info, warn, error,
   fatal, etc.) to distinguish the types of levels and
   different logging based on those levels
 - adding this to method missing allows this gem to support
   methods that may exist in the Ruby Logging library, or
   any other logger that a user of this gem may choose
   to use