### PR TITLE
Adds support for levels and any other Ruby Logger method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## 1.1.0 (2015-12-17)
+
+Add ability to pass in additional logger attributes, such as a log level.
+
+## 1.0.0 (2014-08-05)
+
+Log to multiple destinations with the Ruby logger. There are many logging gems out there, but we didn't find one with the combination of features that we wanted so we wrote our own.
+
+composite_logging supports:
+
+  - Logging to multiple locations, for example the console and a daily log file.
+  - Customizable formatting. See pretty colors and concise timestamps on the console while writing full dates and times to a log file with ANSI codes stripped out.
+  - Tags (aka nested diagnostic context or NDC). Easily identify which method, thread, etc. is responsible for a log entry.
+  - Thread-safe silencing. Prevent specific sections of code from writing to the log.
+Simple configuration in explicit Ruby code or using a builder DSL.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,25 @@ Here's an example of configuring a logger using the builder DSL. The resulting l
 ```ruby
 logger = CompositeLogging.build do
   level Logger::DEBUG
-  
+
   logger do
     output          STDOUT
     formatter       CompositeLogging::ColorFormatter
     datetime_format "%T"
   end
-  
+
   logger MyCustomTaggedLogger do
     output          "./log/myapp.log"
     formatter       MyCustomFormatter
     datetime_format "%F %T"
+  end
+
+  logger MyLoggerWithErrorLevel do
+    output          errors.log
+    formatter       CompositeLogging::Formatter
+    level           Logger::ERROR
+    datetime_format "%F %T"
+    decolorize      true
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ logger = CompositeLogging.build do
   end
 
   logger MyLoggerWithErrorLevel do
-    output          errors.log
+    output          "errors.log"
     formatter       CompositeLogging::Formatter
     level           Logger::ERROR
     datetime_format "%F %T"

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,15 @@
 require "bundler/gem_tasks"
-
 require "rake/testtask"
+require "gemfury/tasks"
 
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
+end
+
+# override rubygems' normal release task to use Gemfury
+Rake::Task['release'].clear
+task :release do
+  Rake::Task['fury:release'].invoke(nil, "patientslikeme")
 end

--- a/composite_logging.gemspec
+++ b/composite_logging.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "gemfury", ">= 0.4.26"
 end

--- a/lib/composite_logging/logger_builder.rb
+++ b/lib/composite_logging/logger_builder.rb
@@ -12,7 +12,7 @@ module CompositeLogging
     def build
       logger = @logger_class.new(*@output_args)
       logger.formatter = @formatter_class.new(@formatter_attrs) if @formatter_class
-      logger.level = @logger_attrs[:level] if @logger_attrs.present?
+      @logger_attrs.each { |k,v| logger.send("#{k}=", v) }
 
       logger
     end

--- a/lib/composite_logging/logger_builder.rb
+++ b/lib/composite_logging/logger_builder.rb
@@ -4,6 +4,7 @@ module CompositeLogging
     def initialize(logger_class = TaggedLogger, &block)
       @logger_class = logger_class
       @formatter_attrs = {}
+      @logger_attrs = {}
 
       instance_eval(&block)
     end
@@ -11,6 +12,8 @@ module CompositeLogging
     def build
       logger = @logger_class.new(*@output_args)
       logger.formatter = @formatter_class.new(@formatter_attrs) if @formatter_class
+      logger.level = @logger_attrs[:level] if @logger_attrs.present?
+
       logger
     end
 
@@ -25,6 +28,8 @@ module CompositeLogging
     def method_missing(name, *args, &block)
       if @formatter_class && @formatter_class.public_instance_methods.include?(:"#{name}=")
         @formatter_attrs[name] = args.first
+      elsif @logger_class.public_instance_methods.include?(:"#{name}=")
+        @logger_attrs[name] = args.first
       else
         super
       end

--- a/lib/composite_logging/version.rb
+++ b/lib/composite_logging/version.rb
@@ -1,3 +1,3 @@
 module CompositeLogging
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
 - in order to have more robust logging, we'd like to
   use the Ruby Logger class levels (info, warn, error,
   fatal, etc.) to distinguish the types of levels and
   different logging based on those levels
 - adding this to method missing allows this gem to support
   methods that may exist in the Ruby Logging library, or
   any other logger that a user of this gem may choose
   to use